### PR TITLE
Adding areaServed to contactPoint as it is in schema.org

### DIFF
--- a/common-schema.json
+++ b/common-schema.json
@@ -466,6 +466,10 @@
               "type": "string",
               "format": "uri",
               "description": "Property. URL which provides a description or further information about this item."
+            },
+            "areaServed": {
+              "type": "string",
+              "description": "Property. The geographic area where a service or offered item is provided. Supersedes serviceArea."
             }
           }
         }


### PR DESCRIPTION
# Description

Adding areaServed to the contactPoint at it is in schema.org, Simplified to the type text at the moment at it is requested for the dataModel.IT/CloudRegion