### PR TITLE
fix: remove builtins - only externals

### DIFF
--- a/pysmartdatamodels/setup.py
+++ b/pysmartdatamodels/setup.py
@@ -14,7 +14,13 @@ DESCRIPTION = 'Hundreds of free data models to model your digital twins, share d
 LONG_DESCRIPTION = (HERE / "README.md").read_text()
 LONG_DESC_TYPE = "text/markdown"
 
-INSTALL_REQUIRES = ["collections", "json", "jsonref", "jsonschema", "pytz", "requests", "sys", "validate", "datetime"]
+INSTALL_REQUIRES = [
+    # "collections", "json" # These are builtins
+    "jsonref", "jsonschema", "pytz", "requests", 
+    # "sys", # another builtin
+    # "validate", # Does not appear to be used
+    # "datetime" # Does not appear to be used
+    ]
 
 setup(name=PACKAGE_NAME,
       version=VERSION,


### PR DESCRIPTION
fix: poetry install issue as show in PR #37 

INSTALL_REQUIRES should not be builtins

Additionally 2 new dependencies are listed `validate` and `datetime`  and don't appear to be used, 
the source code for `validate` is only available as a tar package and no maintenance visible on [pypa](https://pypi.org/project/validate/) 

