### PR TITLE
Make the schemas usable in a validator

### DIFF
--- a/Entity-ngsiv2-datamodels-schema.json
+++ b/Entity-ngsiv2-datamodels-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://smart-data-models.github.io/data-models/Entity-ngsiv2-datamodels-schema.json",
   "title": "NGSIv2 Entity. Normalized Format for Smart Data Models",
   "description": "NGSIv2 Entity. Normalized Format aligned with the usage given by Smart Data Models. Restrictions: geo:point, geo:line, geo:polygon, geo:box not covered. keyValues representation not covered",

--- a/common-schema.json
+++ b/common-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://smart-data-models.github.io/data-models/common-schema.json",
   "title": "Common definitions for  Harmonized Data Models",
   "definitions": {

--- a/schema-org.json
+++ b/schema-org.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://smart-data-models.github.io/data-models/common-schema.json",
   "title": "Common definitions for data models coming from schema.org",
   "definitions": {

--- a/templates/dataModel/schema.json
+++ b/templates/dataModel/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$schemaVersion": "0.0.1",
   "$id": "",
   "title": "",

--- a/templates/dataModel_for_submision/schema.json
+++ b/templates/dataModel_for_submision/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$schemaVersion": "0.0.1",
   "$id": "https://smart-data-models.github.io/dataModel.Energy/ThreePhaseAcMeasurement/schema.json",
   "title": "Smart Data Models - Energy / Three Phase AC Measurement",

--- a/terms.jsonld
+++ b/terms.jsonld
@@ -1,4 +1,4 @@
-{"$schema": "http://json-schema.org/schema#", 
+{"$schema": "https://json-schema.org/draft/2020-12/schema", 
 "$id": "https://smart-data-models.github.io/data-models/terms.jsonld", 
 "title": "Terms included into the Smart Data Models", 
 "definitions": {"activityType": "The action performed (e.g. Drive). Normative References: [https://schema.org/Action](https://schema.org/Action), [https://www.w3.org/TR/activitystreams-vocabulary/#activity-types](https://www.w3.org/TR/activitystreams-vocabulary/#activity-types), [https://health-lifesci.schema.org/PhysicalActivityCategory](https://health-lifesci.schema.org/PhysicalActivityCategory)", 


### PR DESCRIPTION
It seems like "http://json-schema.org/schema#" is deprecated and prevent the associated schema to be used in a JSON validator.
As "https://json-schema.org/draft/2020-12/schema" corresponds to the up-to-date version, I propose to change the line like this.
Also It should be modify in every schema of smart data models